### PR TITLE
Don't load and decode cached images

### DIFF
--- a/source/webp-machine.ts
+++ b/source/webp-machine.ts
@@ -57,6 +57,7 @@ export class WebpMachine {
 		if (/\.webp$/i.test(src)) {
 			if (this.cache[src]) {
 				image.src = this.cache[src]
+				return
 			}
 			try {
 				const webpData = await loadBinaryData(src)


### PR DESCRIPTION
Currently images are downloaded and decoded even if they are already cached.